### PR TITLE
docs: added StorageClass reference in the shared resources documentation

### DIFF
--- a/docs/ethereum/reference/node.md
+++ b/docs/ethereum/reference/node.md
@@ -257,6 +257,8 @@ cpu requests and limits must use the pattern `^[1-9][0-9]*m?$` for example `1000
 
 `memoryLimit` can't be less than `memory`.
 
+`storageClass` field is immutable, it cannot be changed after creation.
+
 ## rpc
 
 `rpc` enables the HTTP RPC server.

--- a/docs/ethereum2/reference/beacon.md
+++ b/docs/ethereum2/reference/beacon.md
@@ -118,6 +118,7 @@ GRPC gateway is only supported by `prysm` client.
 | memory      | string | memory this node requires                   | `8Gi`   |
 | memoryLimit | string | memory this node is limited to              | `16Gi`  |
 | storage     | string | disk space this node requires               | `200Gi` |
+| storageClass | string | Node volume storage class                  | Cluster's default storage class will be used as defined by cluster admin or cloud provider  |
 
 memory and storage requests and limits must use the pattern `^[1-9][0-9]*[KMGTPE]i$` for example `1500Mi`, `30Gi`, and `1Ti`.
 
@@ -126,3 +127,6 @@ cpu requests and limits must use the pattern `^[1-9][0-9]*m?$` for example `1000
 `cpuLimit` can't be less than `cpu`.
 
 `memoryLimit` can't be less than `memory`.
+
+`storageClass` field is immutable, it cannot be changed after creation.
+

--- a/docs/filecoin/reference/node.md
+++ b/docs/filecoin/reference/node.md
@@ -35,3 +35,6 @@ cpu requests and limits must use the pattern `^[1-9][0-9]*m?$` for example `1000
 `cpuLimit` can't be less than `cpu`.
 
 `memoryLimit` can't be less than `memory`.
+
+`storageClass` field is immutable, it cannot be changed after creation.
+

--- a/docs/ipfs/reference/node.md
+++ b/docs/ipfs/reference/node.md
@@ -70,6 +70,7 @@ $ ipfs-key -type Ed25519 | base64
 | memory      | string | memory this node requires                   | `2Gi`  |
 | memoryLimit | string | memory this node is limited to              | `4Gi`  |
 | storage     | string | disk space this node requires               | `10Gi` |
+| storageClass | string | Node volume storage class                   | Cluster's default storage class will be used as defined by cluster admin or cloud provider |
 
 memory and storage requests and limits must use the pattern `^[1-9][0-9]*[KMGTPE]i$` for example `1500Mi`, `30Gi`, and `1Ti`.
 
@@ -78,3 +79,6 @@ cpu requests and limits must use the pattern `^[1-9][0-9]*m?$` for example `1000
 `cpuLimit` can't be less than `cpu`.
 
 `memoryLimit` can't be less than `memory`.
+
+`storageClass` field is immutable, it cannot be changed after creation.
+


### PR DESCRIPTION
Playing around with the storage resource, I noticed the `storageClass` field is not documented across the APIs despite being a [shared resource](https://github.com/kotalco/kotal/blob/3ab66b63bb9bb961daabdce9f2d088c4cf618b57/apis/shared/resources.go#L29).

I've added two lines, the `storageClass` information within the table and what's currently under validation (_the field is immutable, it cannot be changed after creation_).

Please let me know your thoughts or if there's anything you want to change/implement.

In addition, as a question, I would like to know if you are looking to "standardize" this part since the `resources` table is different in different APIs. For example, [Ethereum](https://docs.kotal.co/reference/ethereum#resources) against [Ethereum 2.0](https://docs.kotal.co/reference/ethereum2#resources)